### PR TITLE
Tasks and bugs that were converted to another type still showing as tasks or bugs - Fix and Tests

### DIFF
--- a/src/Ether.Contracts/Interfaces/IRepository.cs
+++ b/src/Ether.Contracts/Interfaces/IRepository.cs
@@ -32,6 +32,9 @@ namespace Ether.Contracts.Interfaces
         T GetSingle<T>(Expression<Func<T, bool>> predicate)
             where T : BaseDto;
 
+        Task<IEnumerable<T>> GetByFilteredArrayAsync<T>(string array, string[] elements)
+            where T : BaseDto;
+
         Task<TProjection> GetFieldValueAsync<TType, TProjection>(Expression<Func<TType, bool>> predicate, Expression<Func<TType, TProjection>> projection)
             where TType : BaseDto;
 
@@ -71,6 +74,9 @@ namespace Ether.Contracts.Interfaces
             where T : BaseDto;
 
         long Delete<T>(Expression<Func<T, bool>> predicate)
+            where T : BaseDto;
+
+        Task<bool> DeleteAsync<T>(Expression<Func<T, bool>> predicate)
             where T : BaseDto;
 
         Task<long> CountAsync<T>()

--- a/src/Ether.Core/Data/MongoRepository.cs
+++ b/src/Ether.Core/Data/MongoRepository.cs
@@ -150,6 +150,16 @@ namespace Ether.Core.Data
             return (T)await GetSingleAsync(id, typeof(T));
         }
 
+        public async Task<IEnumerable<T>> GetByFilteredArrayAsync<T>(string array, string[] elements)
+            where T : BaseDto
+        {
+            var filter = Builders<T>.Filter.AnyIn(array, elements);
+
+            return await GetCollectionFor<T>()
+                .Find(filter)
+                .ToListAsync();
+        }
+
         public async Task<TProjection> GetFieldValueAsync<TType, TProjection>(Expression<Func<TType, bool>> predicate, Expression<Func<TType, TProjection>> projection)
             where TType : BaseDto
         {
@@ -275,6 +285,15 @@ namespace Ether.Core.Data
                 .DeleteMany(predicate);
 
             return result.DeletedCount;
+        }
+
+        public async Task<bool> DeleteAsync<T>(Expression<Func<T, bool>> predicate)
+            where T : BaseDto
+        {
+            await GetCollectionFor<T>()
+                .DeleteManyAsync(predicate);
+
+            return true;
         }
 
         public async Task<long> CountAsync<T>()

--- a/src/Ether.Vsts/Commands/DeleteWorkItems.cs
+++ b/src/Ether.Vsts/Commands/DeleteWorkItems.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using Ether.Contracts.Interfaces.CQS;
+
+namespace Ether.Vsts.Commands
+{
+    public class DeleteWorkItems : ICommand
+    {
+        public DeleteWorkItems(IEnumerable<int> ids)
+        {
+            Ids = ids;
+        }
+
+        public IEnumerable<int> Ids { get; }
+    }
+}

--- a/src/Ether.Vsts/Handlers/Commands/DeleteWorkItemsHandler.cs
+++ b/src/Ether.Vsts/Handlers/Commands/DeleteWorkItemsHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Ether.Contracts.Interfaces;
+using Ether.Contracts.Interfaces.CQS;
+using Ether.Vsts.Commands;
+using Ether.Vsts.Dto;
+using static Ether.Contracts.Types.NullUtil;
+
+namespace Ether.Vsts.Handlers.Commands
+{
+    public class DeleteWorkItemsHandler : ICommandHandler<DeleteWorkItems>
+    {
+        private readonly IRepository _repository;
+
+        public DeleteWorkItemsHandler(IRepository repository)
+        {
+            _repository = repository;
+        }
+
+        public async Task Handle(DeleteWorkItems command)
+        {
+            CheckIfArgumentNull(command.Ids, nameof(command.Ids));
+
+            if (!command.Ids.Any())
+            {
+                return;
+            }
+
+            foreach (var id in command.Ids)
+            {
+                await _repository.DeleteAsync<WorkItem>(workitem => workitem.WorkItemId == id);
+            }
+
+            var idsInStrings = command.Ids.Select(id => id.ToString());
+            var teamMembers = await _repository.GetByFilteredArrayAsync<TeamMember>("RelatedWorkItems", idsInStrings.ToArray());
+
+            foreach (var teamMember in teamMembers)
+            {
+                var remainingIds = teamMember.RelatedWorkItems
+                    .Except(command.Ids)
+                    .ToArray();
+
+                await _repository.UpdateFieldValue(teamMember, m => m.RelatedWorkItems, remainingIds);
+            }
+        }
+    }
+}

--- a/src/Ether.Vsts/Handlers/Commands/DeleteWorkItemsHandler.cs
+++ b/src/Ether.Vsts/Handlers/Commands/DeleteWorkItemsHandler.cs
@@ -26,13 +26,10 @@ namespace Ether.Vsts.Handlers.Commands
                 return;
             }
 
-            foreach (var id in command.Ids)
-            {
-                await _repository.DeleteAsync<WorkItem>(workitem => workitem.WorkItemId == id);
-            }
+            await _repository.DeleteAsync<WorkItem>(workitem => command.Ids.Contains(workitem.WorkItemId));
 
             var idsInStrings = command.Ids.Select(id => id.ToString());
-            var teamMembers = await _repository.GetByFilteredArrayAsync<TeamMember>("RelatedWorkItems", idsInStrings.ToArray());
+            var teamMembers = await _repository.GetAsync<TeamMember>(m => m.RelatedWorkItems.Any(w => command.Ids.Contains(w)));
 
             foreach (var teamMember in teamMembers)
             {

--- a/src/Ether.Vsts/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandler.cs
+++ b/src/Ether.Vsts/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandler.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Ether.Contracts.Interfaces;
+using Ether.Contracts.Interfaces.CQS;
+using Ether.Vsts.Dto;
+using Ether.Vsts.Interfaces;
+using Ether.Vsts.Queries;
+
+namespace Ether.Vsts.Handlers.Queries
+{
+    public class FetchWorkItemsOtherThanBugsAndTasksHandler : IQueryHandler<FetchWorkItemsOtherThanBugsAndTasks, IEnumerable<int>>
+    {
+        private readonly IVstsClientFactory _clientFactory;
+        private readonly IRepository _repository;
+
+        public FetchWorkItemsOtherThanBugsAndTasksHandler(IVstsClientFactory clientFactory, IRepository repository)
+        {
+            _clientFactory = clientFactory;
+            _repository = repository;
+        }
+
+        public async Task<IEnumerable<int>> Handle(FetchWorkItemsOtherThanBugsAndTasks query)
+        {
+            var inProgressWorkItems = await _repository.GetByFilteredArrayAsync<WorkItem>("Fields.v", new[] { "New", "Active" });
+            var ids = inProgressWorkItems.Select(workItem => Convert.ToInt32(workItem.Fields["System.Id"])).ToArray();
+
+            if (!ids.Any())
+            {
+                return Enumerable.Empty<int>();
+            }
+
+            var client = await _clientFactory.GetClient();
+            var workItems = await client.GetWorkItemsAsync(ids);
+            var result = new List<int>();
+
+            foreach (var workItem in workItems)
+            {
+                var workItemType = workItem.Fields?.Where(field => field.Key == "System.WorkItemType");
+
+                if (!workItemType.Any())
+                {
+                    return Enumerable.Empty<int>();
+                }
+
+                if (workItemType.First().Value != "Task" && workItemType.First().Value != "Bug")
+                {
+                    result.Add(workItem.Id);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Ether.Vsts/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandler.cs
+++ b/src/Ether.Vsts/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandler.cs
@@ -24,6 +24,8 @@ namespace Ether.Vsts.Handlers.Queries
         public async Task<IEnumerable<int>> Handle(FetchWorkItemsOtherThanBugsAndTasks query)
         {
             var inProgressWorkItems = await _repository.GetByFilteredArrayAsync<WorkItem>("Fields.v", new[] { "New", "Active" });
+
+            // TODO: Find better way to query this
             var ids = inProgressWorkItems.Select(workItem => Convert.ToInt32(workItem.Fields["System.Id"])).ToArray();
 
             if (!ids.Any())

--- a/src/Ether.Vsts/Jobs/WorkItemsSyncJob.cs
+++ b/src/Ether.Vsts/Jobs/WorkItemsSyncJob.cs
@@ -56,6 +56,10 @@ namespace Ether.Vsts.Jobs
             var workItems = await _mediator.RequestCollection<FetchWorkItemsFromProject, WorkItemViewModel>(new FetchWorkItemsFromProject(teamMember));
             _logger.LogInformation("Found {workitemsCount} workitems for '{teamMember}'.", workItems.Count(), teamMember.Email);
             await _mediator.Execute(new SaveWorkItemsForUser(workItems, teamMember));
+            _logger.LogInformation("Fetching workitems other than Bugs and Tasks.");
+            var workItemsToDeleteIds = await _mediator.RequestCollection<FetchWorkItemsOtherThanBugsAndTasks, int>(new FetchWorkItemsOtherThanBugsAndTasks());
+            _logger.LogInformation("Deleting workitems other than Bugs and Tasks.");
+            await _mediator.Execute(new DeleteWorkItems(workItemsToDeleteIds));
         }
     }
 }

--- a/src/Ether.Vsts/Queries/FetchWorkItemsOtherThanBugsAndTasks.cs
+++ b/src/Ether.Vsts/Queries/FetchWorkItemsOtherThanBugsAndTasks.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using Ether.Contracts.Interfaces.CQS;
+
+namespace Ether.Vsts.Queries
+{
+    public class FetchWorkItemsOtherThanBugsAndTasks : IQuery<IEnumerable<int>>
+    {
+    }
+}

--- a/tests/Ether.Tests/Handlers/BaseHandlerTest.cs
+++ b/tests/Ether.Tests/Handlers/BaseHandlerTest.cs
@@ -148,6 +148,14 @@ namespace Ether.Tests.Handlers
                 .Verifiable();
         }
 
+        protected void SetupDelete<T>(Func<Expression, bool> predicateCheck)
+            where T : BaseDto
+        {
+            RepositoryMock.Setup(r => r.DeleteAsync(It.Is<Expression<Func<T, bool>>>(e => predicateCheck(e))))
+                .ReturnsAsync(true)
+                .Verifiable();
+        }
+
         protected virtual void Initialize()
         {
         }

--- a/tests/Ether.Tests/Handlers/Commands/DeleteWorkItemsHandlerTests.cs
+++ b/tests/Ether.Tests/Handlers/Commands/DeleteWorkItemsHandlerTests.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Ether.ViewModels;
+using Ether.Vsts.Commands;
+using Ether.Vsts.Dto;
+using Ether.Vsts.Handlers.Commands;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace Ether.Tests.Handlers.Commands
+{
+    [TestFixture]
+    public class DeleteWorkItemsHandlerTests : BaseHandlerTest
+    {
+        private DeleteWorkItemsHandler _handler;
+
+        [Test]
+        public void ShouldThrowExceptionIfIdsIsNull()
+        {
+            _handler.Awaiting(h => h.Handle(new DeleteWorkItems(null)))
+                .Should().Throw<ArgumentNullException>();
+        }
+
+        [Test]
+        public async Task ShouldNotDoAnythingIfNoIds()
+        {
+            await _handler.Handle(new DeleteWorkItems(Enumerable.Empty<int>()));
+
+            RepositoryMock.Verify(r => r.DeleteAsync<WorkItem>(It.IsAny<Guid>()), Times.Never);
+        }
+
+        protected override void Initialize()
+        {
+            _handler = new DeleteWorkItemsHandler(RepositoryMock.Object);
+        }
+    }
+}

--- a/tests/Ether.Tests/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandlerTests.cs
+++ b/tests/Ether.Tests/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ether.Vsts.Handlers.Queries;
+using Ether.Vsts.Interfaces;
+using Ether.Vsts.Queries;
+using FizzWare.NBuilder;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using VSTS.Net.Interfaces;
+using VSTS.Net.Models.WorkItems;
+
+namespace Ether.Tests.Handlers.Queries
+{
+    [TestFixture]
+    public class FetchWorkItemsOtherThanBugsAndTasksHandlerTests : BaseHandlerTest
+    {
+        private FetchWorkItemsOtherThanBugsAndTasksHandler _handler;
+        private Mock<IVstsClientFactory> _clientFactoryMock;
+        private Mock<IVstsClient> _clientMock;
+
+        [Test]
+        public async Task ShouldFetchWorkItemsAndWorkItemTypes()
+        {
+            var workitems = Builder<WorkItem>.CreateListOfSize(5)
+                .Build();
+            var ids = workitems.Select(w => w.Id).ToArray();
+
+            _clientMock.Setup(c => c.GetWorkItemsAsync(ids, null, It.IsAny<string[]>(), default(CancellationToken)))
+                .ReturnsAsync(workitems)
+                .Verifiable();
+
+            var result = await _handler.Handle(new FetchWorkItemsOtherThanBugsAndTasks());
+
+            result.Should().HaveCountLessOrEqualTo(workitems.Count);
+            result.Should().OnlyContain(i => workitems.Any(w => w.Id == i));
+
+            _clientFactoryMock.Verify();
+            _clientMock.Verify();
+        }
+
+        protected override void Initialize()
+        {
+            _clientFactoryMock = new Mock<IVstsClientFactory>(MockBehavior.Strict);
+            _clientMock = new Mock<IVstsClient>(MockBehavior.Strict);
+            _handler = new FetchWorkItemsOtherThanBugsAndTasksHandler(_clientFactoryMock.Object, RepositoryMock.Object);
+
+            _clientFactoryMock.Setup(c => c.GetClient(null))
+                .ReturnsAsync(_clientMock.Object)
+                .Verifiable();
+        }
+    }
+}


### PR DESCRIPTION
- GetByFilteredArrayAsync<T>(string array, string[] elements) added to retrieve elements from MongoDB by filtering nested arrays;
- FetchWorkItemsOtherThanBugsAndTasks query and handler added to retrieve all WorkItems in "New" or "Active" state and validate that their System.WorkItemType still equals "Task" or "Bug";
- DeleteWorkItems command and handler added to delete WorkItems with specified WorkitemID (the set of IDs transferred in an array parameter). It also cleans all links to these work items for all TeamMembers;
- WorkItemsSyncJob.cs updated to use new FetchWorkItemsOtherThanBugsAndTasksHandler and DeleteWorkItemsHandler;
- Test coverage.

fixes #39 