### PR TITLE
Calculate amount of workdays and show it in Aggregated Workitems ETA Report

### DIFF
--- a/src/Ether.Contracts/Dto/Reports/AggregatedWorkitemsETAReport.cs
+++ b/src/Ether.Contracts/Dto/Reports/AggregatedWorkitemsETAReport.cs
@@ -18,6 +18,8 @@ namespace Ether.Contracts.Dto.Reports
 
         public List<IndividualETAReport> IndividualReports { get; set; }
 
+        public int Workdays { get; set; }
+
         public class IndividualETAReport
         {
             public string MemberEmail { get; set; }

--- a/src/Ether.Contracts/Types/WorkdaysAmountUtil.cs
+++ b/src/Ether.Contracts/Types/WorkdaysAmountUtil.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+namespace Ether.Contracts.Types
+{
+    public static class WorkdaysAmountUtil
+    {
+        public static int CalculateWorkdaysAmount(DateTime start, DateTime end, params DateTime[] holidays)
+        {
+            start = start.Date;
+            end = end.Date;
+
+            if (start > end)
+            {
+                throw new ArgumentException("Incorrect last day " + end);
+            }
+
+            TimeSpan span = end - start;
+            int businessDays = span.Days + 1;
+            int fullWeekCount = businessDays / 7;
+
+            if (businessDays > fullWeekCount * 7)
+            {
+                int firstDayOfWeek = start.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)start.DayOfWeek;
+                int lastDayOfWeek = end.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)end.DayOfWeek;
+
+                if (lastDayOfWeek < firstDayOfWeek)
+                {
+                    lastDayOfWeek += 7;
+                }
+
+                if (firstDayOfWeek <= 6)
+                {
+                    if (lastDayOfWeek >= 7)
+                    {
+                        businessDays -= 2;
+                    }
+                    else if (lastDayOfWeek >= 6)
+                    {
+                        businessDays -= 1;
+                    }
+                }
+                else if (firstDayOfWeek <= 7 && lastDayOfWeek >= 7)
+                {
+                    businessDays -= 1;
+                }
+            }
+
+            businessDays -= fullWeekCount + fullWeekCount;
+
+            foreach (var holiday in holidays)
+            {
+                var bh = holiday.Date;
+
+                if (start <= bh && bh <= end)
+                {
+                    --businessDays;
+                }
+            }
+
+            return businessDays;
+        }
+    }
+}

--- a/src/Ether.Core/Types/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandler.cs
+++ b/src/Ether.Core/Types/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandler.cs
@@ -58,6 +58,8 @@ namespace Ether.Core.Types.Handlers.Commands
                 report.IndividualReports.Add(individualReport);
             }
 
+            report.Workdays = WorkdaysAmount(command.Start, command.End);
+
             return report;
         }
 
@@ -160,6 +162,52 @@ namespace Ether.Core.Types.Handlers.Commands
             }
 
             return allMembers;
+        }
+
+        private int WorkdaysAmount(DateTime start, DateTime end)
+        {
+            start = start.Date;
+            end = end.Date;
+
+            if (start > end)
+            {
+                throw new ArgumentException("Incorrect last day " + end);
+            }
+
+            TimeSpan span = end - start;
+            int businessDays = span.Days + 1;
+            int fullWeekCount = businessDays / 7;
+
+            if (businessDays > fullWeekCount * 7)
+            {
+                int firstDayOfWeek = start.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)start.DayOfWeek;
+                int lastDayOfWeek = end.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)end.DayOfWeek;
+
+                if (lastDayOfWeek < firstDayOfWeek)
+                {
+                    lastDayOfWeek += 7;
+                }
+
+                if (firstDayOfWeek <= 6)
+                {
+                    if (lastDayOfWeek >= 7)
+                    {
+                        businessDays -= 2;
+                    }
+                    else if (lastDayOfWeek >= 6)
+                    {
+                        businessDays -= 1;
+                    }
+                }
+                else if (firstDayOfWeek <= 7 && lastDayOfWeek >= 7)
+                {
+                    businessDays -= 1;
+                }
+            }
+
+            businessDays -= fullWeekCount + fullWeekCount;
+
+            return businessDays;
         }
     }
 }

--- a/src/Ether.Core/Types/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandler.cs
+++ b/src/Ether.Core/Types/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandler.cs
@@ -9,6 +9,7 @@ using Ether.Contracts.Types;
 using Ether.Core.Types.Commands;
 using Ether.ViewModels;
 using Microsoft.Extensions.Logging;
+using static Ether.Contracts.Types.WorkdaysAmountUtil;
 
 namespace Ether.Core.Types.Handlers.Commands
 {
@@ -58,7 +59,7 @@ namespace Ether.Core.Types.Handlers.Commands
                 report.IndividualReports.Add(individualReport);
             }
 
-            report.Workdays = WorkdaysAmount(command.Start, command.End);
+            report.Workdays = CalculateWorkdaysAmount(command.Start, command.End);
 
             return report;
         }
@@ -162,52 +163,6 @@ namespace Ether.Core.Types.Handlers.Commands
             }
 
             return allMembers;
-        }
-
-        private int WorkdaysAmount(DateTime start, DateTime end)
-        {
-            start = start.Date;
-            end = end.Date;
-
-            if (start > end)
-            {
-                throw new ArgumentException("Incorrect last day " + end);
-            }
-
-            TimeSpan span = end - start;
-            int businessDays = span.Days + 1;
-            int fullWeekCount = businessDays / 7;
-
-            if (businessDays > fullWeekCount * 7)
-            {
-                int firstDayOfWeek = start.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)start.DayOfWeek;
-                int lastDayOfWeek = end.DayOfWeek == DayOfWeek.Sunday ? 7 : (int)end.DayOfWeek;
-
-                if (lastDayOfWeek < firstDayOfWeek)
-                {
-                    lastDayOfWeek += 7;
-                }
-
-                if (firstDayOfWeek <= 6)
-                {
-                    if (lastDayOfWeek >= 7)
-                    {
-                        businessDays -= 2;
-                    }
-                    else if (lastDayOfWeek >= 6)
-                    {
-                        businessDays -= 1;
-                    }
-                }
-                else if (firstDayOfWeek <= 7 && lastDayOfWeek >= 7)
-                {
-                    businessDays -= 1;
-                }
-            }
-
-            businessDays -= fullWeekCount + fullWeekCount;
-
-            return businessDays;
         }
     }
 }

--- a/src/Ether.ViewModels/AggregatedWorkitemsETAReportViewModel.cs
+++ b/src/Ether.ViewModels/AggregatedWorkitemsETAReportViewModel.cs
@@ -12,6 +12,8 @@ namespace Ether.ViewModels
 
         public IEnumerable<IndividualETAReport> IndividualReports { get; set; }
 
+        public int Workdays { get; set; }
+
         public int TotalResolved => IndividualReports.Sum(r => r.TotalResolved);
 
         public float EstimatedToComplete => IndividualReports.Sum(r => r.EstimatedToComplete);

--- a/src/Ether/Components/Reports/AggregatedWorkitemsETAReport.razor
+++ b/src/Ether/Components/Reports/AggregatedWorkitemsETAReport.razor
@@ -50,6 +50,10 @@
             <th colspan="2">Estimated/Completed:</th>
             <td colspan="2">@Report.EstimatedToCompletedRatio.ToString("F2")</td>
         </tr>
+		<tr>
+			<th>Workdays:</th>
+			<td colspan="6">@Report.Workdays</td>
+		</tr>
     </MatTableFooter>
 </MatOverried.MatTable>
 

--- a/tests/Ether.Tests/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandlerTests.cs
+++ b/tests/Ether.Tests/Handlers/Commands/GenerateAggregatedWorkitemsETAReportHandlerTests.cs
@@ -72,6 +72,7 @@ namespace Ether.Tests.Handlers.Commands
 
             await InvokeAndVerify<AggregatedWorkitemsETAReport>(Command, (report, reportId) =>
             {
+                report.Workdays.Should().Be(0);
                 report.IndividualReports.Should().BeEmpty();
             });
         }
@@ -91,6 +92,7 @@ namespace Ether.Tests.Handlers.Commands
 
             await InvokeAndVerify<AggregatedWorkitemsETAReport>(Command, (report, reportId) =>
             {
+                report.Workdays.Should().BeGreaterThan(0);
                 report.IndividualReports.Should().HaveCount(1);
                 VerifyReportFor(jim, report, expectedValuesForJim);
             });


### PR DESCRIPTION
- Added Workdays property to AggregatedWorkitemsETAReport and its view model;
- Added WorkdaysAmount(DateTime start, DateTime end) method to generate a report handler to calculate a number of workdays for a selected period;
- Added Workdays column to AggregatedWorkitemsETAReport.razor page;
- Added tests.

closes #41 