### PR TITLE
Skip broken work item resolutions

### DIFF
--- a/src/Ether.Vsts/Types/Classifiers/ClosedTasksWorkItemsClassifier.cs
+++ b/src/Ether.Vsts/Types/Classifiers/ClosedTasksWorkItemsClassifier.cs
@@ -14,7 +14,7 @@ namespace Ether.Vsts.Types.Classifiers
         {
             var resolutionUpdate = request.WorkItem.Updates.LastOrDefault(u => WasClosedByTeamMember(u, request));
             var wasEverResolved = request.WorkItem.Updates.Any(u => u[WorkItemStateField].NewValue == WorkItemStateResolved);
-            if (resolutionUpdate == null || wasEverResolved)
+            if (resolutionUpdate == null || wasEverResolved || resolutionUpdate[WorkItemClosedByField].NewValue == null || resolutionUpdate[WorkItemChangedDateField].NewValue == null)
             {
                 return Enumerable.Empty<IWorkItemEvent>();
             }


### PR DESCRIPTION
Workitem resolutions that don't contain required fields (ClosedBy, ChangedDate) now skipped when generating reports.

fixes #59 