### PR TITLE
Use correct NetOffice Outlook library

### DIFF
--- a/src/Ether.EmailGenerator/Ether.EmailGenerator.csproj
+++ b/src/Ether.EmailGenerator/Ether.EmailGenerator.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel" Version="4.1.1" />
     <PackageReference Include="MaterialDesignThemes" Version="3.0.1" />
-    <PackageReference Include="NetOffice.Outlook" Version="1.7.4.4" />
+    <PackageReference Include="NetOfficeFw.Outlook" Version="1.7.4.11" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Switching from NetOffice to NetOfficeFw packages as they are more recent and the **NetOffice 1.7.4.4** is invalid release.

PS: When using nuget packages **NetOffice.Core** and **NetOffice.Outlook** in versions 1.7.4.4 you will in fact use NetOffice code from 1.7.3 release, because that package contain old assemblies.

By using **NetOfficeFw** packages, you will get the actual 1.7.4 source code and all the latest bugfixes (eg. with fix for https://github.com/NetOfficeFw/NetOffice/issues/223 which affects MS Outlook).