### PR TITLE
Fix issue with missing workitems in Pod 1 Working items report.

### DIFF
--- a/tests/Ether.Tests/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandlerTests.cs
+++ b/tests/Ether.Tests/Handlers/Queries/FetchWorkItemsOtherThanBugsAndTasksHandlerTests.cs
@@ -43,9 +43,6 @@ namespace Ether.Tests.Handlers.Queries
                     WorkItems = references
                 })
                 .Verifiable();
-            _clientMock.Setup(c => c.GetWorkItemsAsync(ids, null, It.IsAny<string[]>(), default(CancellationToken)))
-                .ReturnsAsync(workitems)
-                .Verifiable();
 
             RepositoryMock.Setup(r => r.GetByFilteredArrayAsync<Ether.Vsts.Dto.WorkItem>("Fields.v", It.IsAny<string[]>()))
                 .ReturnsAsync(workitems.Select(w => new Ether.Vsts.Dto.WorkItem


### PR DESCRIPTION
There was an issue when collected workitems from ADO was removed from database as not a Bug or Task.
Issue was in some query limitations. It was reproduced in case when Ether makes a Query for 290 workitems to get their types, but received all information only for 280, looks like because of response limits (maybe paging was applied). 10 missed items was a Bugs or Task but algorithm was not handle such situation and decided that items are not Bugs or Tasks and than Ether removed that missing items from own database. 

**Proposed TEMPORARY fix solves current issue on ADO side. Full fix should make all WiQL queries by batches, or should handle multipage response.**